### PR TITLE
Don't downcase "salesInvoices" in URL path

### DIFF
--- a/lib/business_central/object/sales_invoice_line.rb
+++ b/lib/business_central/object/sales_invoice_line.rb
@@ -21,7 +21,7 @@ module BusinessCentral
 
         super(client, args)
         @parent_path << {
-          path: parent.downcase,
+          path: parent,
           id: parent_id
         }
       end


### PR DESCRIPTION
This was causing the url to be constructed as `salesinvoices` instead
of `salesInvoices` which meant business central was returning a 404
when trying to perform requests on the `salesInvoiceLines` endpoint