### PR TITLE
[MID-1399] Introduce `Microsoft.NAV` requests as a concept

### DIFF
--- a/lib/business_central/object/base.rb
+++ b/lib/business_central/object/base.rb
@@ -106,6 +106,23 @@ module BusinessCentral
         )
       end
 
+      def microsoft_nav_post(id)
+        if !method_supported?(:microsoft_nav_post)
+          raise BusinessCentral::NoSupportedMethod.new(:microsoft_nav_post, object_methods)
+        end
+
+        Request.post(
+          @client,
+          build_url(
+            parent_path: @parent_path,
+            child_path: object_name,
+            child_id: id,
+            microsoft_nav: "post"
+          ),
+          {}
+        )
+      end
+
       protected
 
       def valid_parent?(parent)
@@ -114,12 +131,13 @@ module BusinessCentral
         raise InvalidArgumentException, "parents allowed: #{object_parent_name.join(', ')}"
       end
 
-      def build_url(parent_path: [], child_path: '', child_id: '', filter: '')
+      def build_url(parent_path: [], child_path: '', child_id: '', microsoft_nav: '', filter: '')
         URLBuilder.new(
           base_url: client.url,
           parent_path: parent_path,
           child_path: child_path,
           child_id: child_id,
+          microsoft_nav: microsoft_nav,
           filter: filter
         ).build
       end

--- a/lib/business_central/object/sales_invoice.rb
+++ b/lib/business_central/object/sales_invoice.rb
@@ -54,6 +54,7 @@ module BusinessCentral
         post
         patch
         delete
+        microsoft_nav_post
       ].freeze
 
       navigation :sales_invoice_line

--- a/lib/business_central/object/url_builder.rb
+++ b/lib/business_central/object/url_builder.rb
@@ -14,12 +14,13 @@ module BusinessCentral
         end
       end
 
-      def initialize(base_url:, parent_path: [], child_path: '', child_id: '', child_code: '', filter: '')
+      def initialize(base_url:, parent_path: [], child_path: '', child_id: '', child_code: '', microsoft_nav: '', filter: '')
         @base_url = base_url.to_s
         @parent_path = parent_path || []
         @child_path = child_path.to_s
         @child_id = child_id.to_s
         @child_code = child_code.to_s
+        @microsoft_nav = microsoft_nav.to_s
         @filter = filter.to_s
       end
 
@@ -27,6 +28,7 @@ module BusinessCentral
         url = @base_url
         url += build_parent_path
         url += build_child_path
+        url += build_microsoft_nav_path
         url += build_filter
         url
       end
@@ -46,6 +48,12 @@ module BusinessCentral
         url += "/#{@child_path}" if @child_path.present?
         url += "(#{@child_id})" if @child_id.present?
         url += "('#{odata_encode(@child_code)}')" if @child_code.present?
+        url
+      end
+
+      def build_microsoft_nav_path
+        url = ''
+        url += "/Microsoft.NAV.#{@microsoft_nav}" if @microsoft_nav.present?
         url
       end
 

--- a/test/business_central/object/sales_invoice_test.rb
+++ b/test/business_central/object/sales_invoice_test.rb
@@ -153,4 +153,12 @@ class BusinessCentral::Object::SalesInvoiceTest < Minitest::Test
                       .sales_invoice_line.find_all
     assert_equal response.first[:description], 'salesInvoiceLine1'
   end
+
+  def test_microsoft_nav_post
+    test_id = '0111245'
+    stub_request(:post, /salesInvoices\(#{test_id}\)\/Microsoft.NAV.post/)
+      .to_return(status: 204)
+
+    assert @sales_invoice.microsoft_nav_post(test_id)
+  end
 end


### PR DESCRIPTION
According to the Dynamics API docs, there is a standard interface for non-CRUD actions on an object called `Microsoft.NAV`. This commit introduces this as a concept, and implements it for salesInvoices, where the method `Microsoft.NAV.post` is used to "post" an invoice within Dynamics (which means converts it from a draft to an open invoice, ready for payment).

API docs at https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/api-reference/v2.0/resources/dynamics_salesinvoice