### PR TITLE
Add `Microsoft.NAV.cancel` as an API method

### DIFF
--- a/lib/business_central/object/base.rb
+++ b/lib/business_central/object/base.rb
@@ -123,6 +123,23 @@ module BusinessCentral
         )
       end
 
+      def microsoft_nav_cancel(id)
+        if !method_supported?(:microsoft_nav_cancel)
+          raise BusinessCentral::NoSupportedMethod.new(:microsoft_nav_cancel, object_methods)
+        end
+
+        Request.post(
+          @client,
+          build_url(
+            parent_path: @parent_path,
+            child_path: object_name,
+            child_id: id,
+            microsoft_nav: "cancel"
+          ),
+          {}
+        )
+      end
+
       protected
 
       def valid_parent?(parent)

--- a/lib/business_central/object/sales_invoice.rb
+++ b/lib/business_central/object/sales_invoice.rb
@@ -55,6 +55,7 @@ module BusinessCentral
         patch
         delete
         microsoft_nav_post
+        microsoft_nav_cancel
       ].freeze
 
       navigation :sales_invoice_line

--- a/test/business_central/object/sales_invoice_test.rb
+++ b/test/business_central/object/sales_invoice_test.rb
@@ -161,4 +161,12 @@ class BusinessCentral::Object::SalesInvoiceTest < Minitest::Test
 
     assert @sales_invoice.microsoft_nav_post(test_id)
   end
+
+  def test_microsoft_nav_cancel
+    test_id = '0111245'
+    stub_request(:post, /salesInvoices\(#{test_id}\)\/Microsoft.NAV.cancel/)
+      .to_return(status: 204)
+
+    assert @sales_invoice.microsoft_nav_cancel(test_id)
+  end
 end


### PR DESCRIPTION
Use this API method on salesInvoice, so that we can cancel invoices already in Business Central.

API docs at https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/api-reference/v2.0/resources/dynamics_salesinvoice